### PR TITLE
Allow Custom Step Names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,7 @@ fn print_global_stats_stuff(
     println!("Processed {:?} total documents", total_docs);
     println!("-------------------------------------------");
     for (i, el) in processor.pipeline.iter().enumerate() {
-        println!("Step {:?} | {:?}", i, el);
+        println!("Step {:?} | {:?}", processor.steps[i], el);
 
         let step_time_pct = step_fracs.get(&i).unwrap();
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use datamap_rs::partition::{discrete_partition, range_partition};
 use datamap_rs::reshard::reshard;
 use datamap_rs::groupfilter::{group, group_filter};
 use datamap_rs::reservoir_sample::reservoir_sample;
-use datamap_rs::shuffle::shuffle; 
+use datamap_rs::shuffle::shuffle;
 /*
 Map Config layout:
 
@@ -152,16 +152,16 @@ enum Commands {
 
         #[arg(long, value_delimiter = ',')]
         range_groups: Option<Vec<f64>>,
-        
+
         #[arg(long)]
         reservoir_path: Option<PathBuf>,
-        
+
         #[arg(long)]
         num_buckets: Option<usize>,
-        
+
         #[arg(long)]
         max_file_size: Option<usize>,
-        
+
         #[arg(long)]
         bucket_name: Option<String>,
     },
@@ -174,7 +174,7 @@ enum Commands {
         group_dir: PathBuf,
 
         #[arg(required = true, long)]
-        config: PathBuf,        
+        config: PathBuf,
 
         #[arg(long)]
         subext: Option<String>,
@@ -188,7 +188,7 @@ enum Commands {
         output_dir: PathBuf,
 
         #[arg(required = true, long)]
-        config: PathBuf,                
+        config: PathBuf,
     },
 
     Shuffle {
@@ -196,7 +196,7 @@ enum Commands {
         input_dir: PathBuf,
 
         #[arg(required = true, long)]
-        output_dir: PathBuf,  
+        output_dir: PathBuf,
 
         #[arg(required=true, long)]
         num_outputs: usize,
@@ -413,7 +413,7 @@ fn gen_map_single(
 
     output_lines.into_iter().for_each(|(k, v)| {
         let step_output_dir = if k < usize::MAX {
-            output_dir.clone().join(format!("step_{:02}", k))
+            output_dir.clone().join(processor.steps[k].to_string())
         } else {
             output_dir.clone().join("step_final")
         };
@@ -479,7 +479,7 @@ pub fn count(input_dir: &PathBuf, output_file: &PathBuf, count_bytes: Option<Str
                 if value.exists() {
                     text_bytes += value.str().len();
                 }
-            }            
+            }
         }
         total_doc_count.fetch_add(file_len, Ordering::SeqCst);
         total_file_sizes.fetch_add(file_size, Ordering::SeqCst);
@@ -539,7 +539,7 @@ fn main() {
         Commands::ReservoirSample {
             input_dir,
             output_file,
-            key, 
+            key,
             reservoir_size,
             token_weighted,
             text_key
@@ -554,7 +554,7 @@ fn main() {
 
         Commands::RangePartition {
             input_dir,
-            output_dir, 
+            output_dir,
             config,
             value, default_value, range_groups, reservoir_path, num_buckets, max_file_size, bucket_name
 

--- a/src/map_fxn.rs
+++ b/src/map_fxn.rs
@@ -139,7 +139,10 @@ impl PipelineProcessor {
 
             match subconfig.get("step") {
                 Some(step) => {
-                    let step_name = step.as_str().unwrap().to_string();
+                    let step_name = step
+                        .as_str()
+                        .ok_or_else(|| Error::msg("'step' must be a string"))?
+                        .to_string();
                     if step_name == "step_final" {
                         return Err(Error::msg("'step_final' is a reserved step name"));
                     }
@@ -149,6 +152,14 @@ impl PipelineProcessor {
             };
 
         }
+
+        // We need to ensure that all provided steps names are unique, otherwise multiple steps
+        // will write to the same output file, overwriting each other.
+        let unique_steps: HashSet<_> = steps.iter().collect();
+        if unique_steps.len() != steps.len() {
+            return Err(Error::msg("Step names must be unique"));
+        }
+
         Ok(Self { pipeline, steps })
     }
 

--- a/src/map_fxn.rs
+++ b/src/map_fxn.rs
@@ -120,7 +120,7 @@ impl PipelineProcessor {
         let text_field = get_default(&config, "text_field", String::from("text"));
 
         let pipeline_configs = config.get("pipeline").unwrap().as_array().unwrap();
-        for subconfig in pipeline_configs {
+        for (step_num, subconfig) in pipeline_configs.iter().enumerate() {
             let subconfig_name = subconfig.get("name").unwrap().as_str().unwrap();
             let default_json = json!({});
             let mut subconfig_kwargs: Value = subconfig
@@ -148,7 +148,7 @@ impl PipelineProcessor {
                     }
                     steps.push(step_name);
                 }
-                None => steps.push(format!("step_{:02}", steps.len())),
+                None => steps.push(format!("step_{:02}", step_num)),
             };
 
         }

--- a/src/map_fxn.rs
+++ b/src/map_fxn.rs
@@ -138,7 +138,13 @@ impl PipelineProcessor {
             pipeline.push(constructor(&subconfig_kwargs).unwrap());
 
             match subconfig.get("step") {
-                Some(step) => steps.push(step.as_str().unwrap().to_string()),
+                Some(step) => {
+                    let step_name = step.as_str().unwrap().to_string();
+                    if step_name == "step_final" {
+                        return Err(Error::msg("'step_final' is a reserved step name"));
+                    }
+                    steps.push(step_name);
+                }
                 None => steps.push(format!("step_{:02}", steps.len())),
             };
 


### PR DESCRIPTION
This config allows `map` steps to set their own name via `step` arguments, e.g.:

```yaml
name: code_filter
text_field: text
pipeline:
    - name: text_len_filter
      step: invalid_length
      kwargs:
          text_field: text
          lower_bound: 73
          upper_bound: 25468
    - name: float_filter
      step: quality_p00
      kwargs:
          float_field: metadata.stack_edu_redux_combined
          lower_bound: 0.337761
    - name: float_filter
      step: quality_p05
      kwargs:
          float_field: metadata.stack_edu_redux_combined
          lower_bound: 0.385466
```

If `step` is not provided, default convention of using `step_{:02}` formatting is used instead. 